### PR TITLE
fix: use serverDir instead of srcDir for new Nuxt 4 file structure

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -32,7 +32,7 @@ export default defineNuxtModule<ModuleOptions>({
   async setup(options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
 
-    const files = await scanHandlers(resolve(nuxt.options.srcDir, `server/${options.jobsDir}`))
+    const files = await scanHandlers(resolve(nuxt.options.serverDir, options.jobsDir))
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))
 
     nuxt.options.build.transpile.push(runtimeDir)


### PR DESCRIPTION
Nuxt 4 introduces a [new default directory structure](https://nuxt.com/docs/getting-started/upgrade#migrating-to-nuxt-4)

With this new structure enabled on a Nuxt 3 project using the following configuration:
```js
future: {
  compatibilityVersion: 4,
}
```

This module is not working anymore, because the module resolve cron directory to `<srcDir>` which is `app/` by default, and therefore tries to resolve
`app/server/cron/` by default, and not `server/cron/`,

Check it here -> https://stackblitz.com/edit/github-hessqh?file=src/module.ts

I believe it should try to resolve `<serverDir>`, which by default is `<rootDir>/server` when `compatibilityVersion:` is set to 4, and `<srcDir>/server` otherwise.

I believe there is no breaking change for those who havent migrated to the new structure.