### PR TITLE
fix: defineNitroPlugin is undefined after build in nitro.mjs

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -42,6 +42,7 @@ export default defineNuxtModule<ModuleOptions>({
       write: true,
       getContents() {
         return `
+          import { defineNitroPlugin } from '#imports'
           import { createCronHandler } from '${resolve('./runtime/server')}'
           ${files.map((file, index) => `import cronJob${index} from '${file.replace('.ts', '')}'`).join('\n')}
 


### PR DESCRIPTION
Fixes issue with defineNitroPlugin being undefined when running `nuxi preview` in nuxt 4 as reported in #92 
```
.output/server/chunks/nitro/nitro.mjs:13178                                                          
const _FAcPlHCrZY = defineNitroPlugin((nitro) => {                                                                                  
                    ^                                                                                                               
ReferenceError: defineNitroPlugin is not defined                                                                                    
    at file:///.output/server/chunks/nitro/nitro.mjs:13178:21                                                
```